### PR TITLE
Using Java 1.5 to get rid of compiler error

### DIFF
--- a/ckez/pom.xml
+++ b/ckez/pom.xml
@@ -75,8 +75,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>2.3.2</version>
 				<configuration>
-					<source>1.4</source>
-					<target>1.4</target>
+					<source>1.5</source>
+					<target>1.5</target>
 					<excludes>
 						<exclude>**/archive/**</exclude>
 					</excludes>


### PR DESCRIPTION
I got a compiler warning when trying to compile zkckeditor, updating the source/target platform to 1.5 fixed it.
