### PR TITLE
Bug ZKCK-14: Get ckeditor value within client onChange event return empt...

### DIFF
--- a/ckez/src/archive/web/js/ckez/CKeditor.js
+++ b/ckez/src/archive/web/js/ckez/CKeditor.js
@@ -414,7 +414,7 @@ ckez.CKeditor = zk.$extends(zul.Widget, {
 		}
 		
 		if (wgt.$class._checkEditorDirty(editor)) { // Issue #13
-			var val = editor.getData(true); // B-ZKCK-11: avoid fire duplicated events.
+			var val = editor.getSnapshot(); // ZKCK-11, ZKCK-14: avoid firing duplicated events
 			wgt._value = val; //save for onRestore
 			// B70-CKEZ-23: Do not send ahead when fire onChange, it will reverse the queue.
 			wgt.fire('onChange', {value: val});

--- a/test/addon/ckeztest/src/archive/test2/B-ZKCK-14.zul
+++ b/test/addon/ckeztest/src/archive/test2/B-ZKCK-14.zul
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+B-ZKCK-14.zul
+
+	Purpose:
+		
+	Description:
+		
+	History:
+		Fri, Feb 06, 2015  5:59:12 PM, Created by hanhsu
+
+Copyright (C)  Potix Corporation. All Rights Reserved.
+
+-->
+<?init class="org.zkoss.zkplus.databind.AnnotateDataBinderInit" ?>
+<zk xmlns:w="client">
+	<script><![CDATA[
+		function fillTextboxFromCkEditor() {
+			var wgt = zk.Widget.$('$ckeditor'),
+				textbox = zk.Widget.$('$textbox');
+			console.log(wgt.getValue());
+			textbox.setValue(wgt.getValue());
+		}
+	]]></script>
+	<window border="normal" title="hello" id="window"
+		apply="org.zkoss.zktest.test2.B_ZKCK_14_Composer">
+		<vlayout>
+			<label multiline="true">
+				1. type TITLE in the title input box
+				2. type TEST in the editor
+				3. Click your mouse once on outside of the editor
+				4. You should see "<p>TEST</p>" in the button text input box
+			</label>
+			<label value="title" />
+			<textbox visible="true" value="@{window$composer.instruction.title}" />
+			<label value="content" />
+			<ckeditor id="ckeditor" value="@{window$composer.instructionText}" w:onChange="fillTextboxFromCkEditor()" />
+			<label value="invisibleContent" />
+			<textbox id="textbox" value="@{window$composer.instruction.text}" />
+			<button label="SAVE" id="saveButton" />
+		</vlayout>
+	</window>
+</zk>

--- a/test/addon/ckeztest/src/archive/test2/config.properties
+++ b/test/addon/ckeztest/src/archive/test2/config.properties
@@ -72,3 +72,4 @@ B-ZKCK-10.zul=A,H,Ckeditor,popup,onSize
 B-ZKCK-12.zul=A,H,Ckeditor,setValue,fromServer
 B-ZKCK-11.zul=A,H,Ckeditor,getData,FireEvent
 B-ZKCK-13.zul=A,E,Ckeditor,invalidate,restoreValue
+B-ZKCK-14.zul=A,E,Ckeditor,onChange,getData

--- a/test/addon/ckeztest/src/org/zkoss/zktest/test2/B_ZKCK_14_Composer.java
+++ b/test/addon/ckeztest/src/org/zkoss/zktest/test2/B_ZKCK_14_Composer.java
@@ -1,0 +1,74 @@
+/* B_ZKCK_14_Composer.java
+
+	Purpose:
+		
+	Description:
+		
+	History:
+		Fri, Feb 06, 2015  6:00:38 PM, Created by Han
+
+Copyright (C)  Potix Corporation. All Rights Reserved.
+
+This program is distributed under LGPL Version 2.1 in the hope that
+it will be useful, but WITHOUT ANY WARRANTY.
+*/
+package org.zkoss.zktest.test2;
+
+import org.zkoss.zk.ui.Component;
+import org.zkoss.zk.ui.util.GenericForwardComposer;
+
+/**
+ * 
+ * @author Han
+ */
+public class B_ZKCK_14_Composer extends GenericForwardComposer<Component> {
+
+	private static final long serialVersionUID = 595477172241551647L;
+
+	private String instructionText;
+
+    private Instruction instruction;
+
+    public Instruction getInstruction() {
+        return this.instruction;
+    }
+
+    public void setInstruction(final Instruction instruction) {
+        this.instruction = instruction;
+    }
+
+    public String getInstructionText() {
+        return this.instructionText;
+    }
+
+    public void setInstructionText(final String instructionText) {
+        this.instructionText = instructionText;
+    }
+
+    public class Instruction {
+        private String text;
+        private String title;
+
+        public String getText() {
+            return this.text;
+        }
+
+        public void setText(final String text) {
+            this.text = text;
+        }
+
+        public String getTitle() {
+            return this.title;
+        }
+
+        public void setTitle(final String title) {
+            this.title = title;
+        }
+    }
+
+    @Override
+    public void doAfterCompose(Component comp) throws Exception {
+        this.instructionText = null;
+        this.instruction = new Instruction();
+    }
+}

--- a/zkdoc/ckez-release-note
+++ b/zkdoc/ckez-release-note
@@ -4,6 +4,7 @@ Ckez 4.4.6.1
 * Features:
 	
 * Bugs:
+	B-ZKCK-14: Get ckeditor value within client onChange event return empty string
 	
 * Upgrade Notes:
 	
@@ -19,6 +20,7 @@ January 29 2015
 	B-ZKCK-12: Calling Ckeditor.setValue() within doAfterCompose and button click have different result
 	B-ZKCK-11: Changing font family or size does not affect subsequently entered text
 	B-ZKCK-13: Type xml tag value is escaping incorrect after invalidate CKeditor
+
 * Upgrade Notes:
 	+ Upgrade to ckeditor 4.4.6
 	+ Update content value with special characters like angle brackets only need to escape once instead of twice now


### PR DESCRIPTION
...y string